### PR TITLE
receipt-api/4 build logic for receipt processing and storing receipts

### DIFF
--- a/receipt-api-backend/Cargo.lock
+++ b/receipt-api-backend/Cargo.lock
@@ -1989,6 +1989,9 @@ name = "uuid"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "valuable"

--- a/receipt-api-backend/Cargo.toml
+++ b/receipt-api-backend/Cargo.toml
@@ -12,4 +12,4 @@ rocket = { version = "0.5.0-rc.2", features = ["secrets", "json"] }
 rocket_codegen = "0.4.11"
 serde_json = "1.0.94"
 serde = { version = "1.0", features = ["derive"] }
-uuid = "1.3.0"
+uuid = { version = "1.3.0", features = ["v4"] }

--- a/receipt-api-backend/src/main.rs
+++ b/receipt-api-backend/src/main.rs
@@ -1,4 +1,7 @@
+#![feature(once_cell)] // lets me use unstable features -- see lines 16-19
 #[macro_use] extern crate rocket;
+use std::{collections::HashMap, sync::LazyLock};
+use uuid::Uuid;
 
 /* Keeping this imports for now, but they will be removed if I end up not using any of them */
 // use rocket::fs::NamedFile;
@@ -9,6 +12,13 @@
 
 // Receipt struct module with custom Request Guard implementation
 mod receipt;
+
+// this is not going to work with
+// i'll need to use some MUTEX to safely access a cached global HashMap, then unlock/lock it to access it i think
+static mut RECEIPT_CACHE: LazyLock<HashMap<String, String>> = LazyLock::new(|| {
+  let m: HashMap<String, String> = HashMap::new();
+  m
+});
 
 // POST endpoint for processing Receipt objects
 #[post("/receipts/process", format = "application/json", data = "<receipt>")]


### PR DESCRIPTION
This PR adds the main logic for processing a `Receipt` which means making sure the receipt data sent via a `POST` request is valid using the `Request Guard` on the receipt object.

Then if the data is valid then I add up all possible points for the receipt and cash that in memory, the _caching in memory_ bit is proving to be more difficult than expected however.

**Note:** As of creating this PR it is not nearly done, I spent some time getting a `HashMap` set up to store the receipts by _id_ as the key and the receipts accrued _points_ as the value. But it looks like I may need to wrap the `HashMap` in a `Mutex` or some _thread-safe_ wrapper for this in-memory store to work.

This PR addresses issue #4 